### PR TITLE
fix(editor): Fix editor not using entire height

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -32,6 +32,11 @@ html, body {
   overflow: auto;
 }
 
+#input > .cm-editor {
+  width: 100%;
+  height: 100%;
+}
+
 svg {
   font-family: sans-serif;
 }


### PR DESCRIPTION
Fixes an issue where the editor would use less than the available height if it has too little content.