### PR TITLE
feat(editor): Add CodeMirror lang support (highlighting!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .nyc_output
 /coverage
 .idea
+grammar/*.js

--- a/grammar/selena.grammar
+++ b/grammar/selena.grammar
@@ -1,0 +1,46 @@
+@top Sequence { (ObjectDefinition | Message)* }
+
+ObjectDefinition {
+  ObjectKeyword options? ObjectName "=" String
+}
+ObjectName { identifier }
+Outside { outsideIdentifier }
+
+options { "(" Option* ")" }
+Option { identifier }
+
+Message {
+  Outside? Arrow options? (Outside | ObjectName) String? MessageBlock?
+}
+
+ReturnStatement {
+  ReturnKeyword String?
+}
+
+MessageBlock { "{" Message* ReturnStatement? "}" }
+
+@tokens {
+  String { '"' !["\r\n]* '"' }
+
+  identifier { $[a-zA-Z_0-9]+ }
+  outsideIdentifier { "*" }
+
+  LineComment { "#" ![\n]* }
+
+  Arrow { "->" }
+
+  ObjectKeyword { "object" }
+  ReturnKeyword { "return" }
+
+  whitespace { std.whitespace+ }
+
+  "(" ")"
+
+  "{" "}"
+
+  "="
+}
+
+@skip { whitespace | LineComment }
+
+@detectDelim

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@codemirror/basic-setup": "^0.18.2",
         "@codemirror/theme-one-dark": "^0.18.1",
+        "lezer": "^0.13.5",
         "selena": "^0.1.0"
       },
       "devDependencies": {
@@ -21,6 +22,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^5.1.0",
         "html-webpack-plugin": "^5.3.2",
+        "lezer-generator": "^0.13.4",
         "rimraf": "^3.0.2",
         "ts-loader": "^9.2.3",
         "typescript": "^4.3.5",
@@ -5070,6 +5072,18 @@
       "integrity": "sha512-cAiMQZGUo2BD8mpcz7Nv1TlKzWP7YIdIRrX41CiP5bk5t4GHxskOxWUx2iAOuHlz8dO+ivbuXr0J1bfHsWD+lQ==",
       "dependencies": {
         "lezer-tree": "^0.13.2"
+      }
+    },
+    "node_modules/lezer-generator": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/lezer-generator/-/lezer-generator-0.13.4.tgz",
+      "integrity": "sha512-pTWxEgw6U41jM/IwMbhPBPonrcQV5YYL3XoY4QPR7ibOjgo2RaF4wVrdabN1ILtBbGvtHZekTGyrbsqfKnMHMA==",
+      "dev": true,
+      "dependencies": {
+        "lezer": "^0.13.2"
+      },
+      "bin": {
+        "lezer-generator": "dist/lezer-generator.cjs"
       }
     },
     "node_modules/lezer-tree": {
@@ -12922,6 +12936,15 @@
       "integrity": "sha512-cAiMQZGUo2BD8mpcz7Nv1TlKzWP7YIdIRrX41CiP5bk5t4GHxskOxWUx2iAOuHlz8dO+ivbuXr0J1bfHsWD+lQ==",
       "requires": {
         "lezer-tree": "^0.13.2"
+      }
+    },
+    "lezer-generator": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/lezer-generator/-/lezer-generator-0.13.4.tgz",
+      "integrity": "sha512-pTWxEgw6U41jM/IwMbhPBPonrcQV5YYL3XoY4QPR7ibOjgo2RaF4wVrdabN1ILtBbGvtHZekTGyrbsqfKnMHMA==",
+      "dev": true,
+      "requires": {
+        "lezer": "^0.13.2"
       }
     },
     "lezer-tree": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "description": "IDE for the Selena language, a textual description of renderable UML sequence diagrams.",
   "main": "index.js",
   "scripts": {
-    "clean": "rimraf \"dist/*\"",
-    "dev": "webpack --mode development",
-    "prod": "webpack --mode production",
-    "start": "webpack serve --no-hot",
+    "clean": "rimraf \"dist/*\" && rimraf \"grammar/*.js\"",
+    "build-grammar": "lezer-generator grammar/selena.grammar -o grammar/selena.js",
+    "dev": "npm run build-grammar && webpack --mode development",
+    "prod": "npm run build-grammar && webpack --mode production",
+    "start": "npm run build-grammar && webpack serve --no-hot",
     "lint": "eslint --ignore-path .gitignore .",
     "lint-fix": "eslint --fix --ignore-path .gitignore .",
     "test": "npm run lint"
@@ -26,6 +27,7 @@
   "dependencies": {
     "@codemirror/basic-setup": "^0.18.2",
     "@codemirror/theme-one-dark": "^0.18.1",
+    "lezer": "^0.13.5",
     "selena": "^0.1.0"
   },
   "devDependencies": {
@@ -37,6 +39,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "html-webpack-plugin": "^5.3.2",
+    "lezer-generator": "^0.13.4",
     "rimraf": "^3.0.2",
     "ts-loader": "^9.2.3",
     "typescript": "^4.3.5",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import { Command, EditorView, keymap } from '@codemirror/view'
 import { defaultTabBinding } from '@codemirror/commands'
 import { oneDark } from '@codemirror/theme-one-dark'
 
+import { selena } from './selena-language-support'
+
 const LOCALSTORAGE_SAVED = 'seq.save.input'
 
 function update (input: string, outputTo: HTMLElement): void {
@@ -55,6 +57,7 @@ const editorView = new EditorView({
   state: EditorState.create({
     extensions: [
       basicSetup,
+      selena(),
       keymap.of([
         defaultTabBinding,
         { key: 'Ctrl-s', run: updateDiagram }

--- a/src/selena-language-support.ts
+++ b/src/selena-language-support.ts
@@ -1,0 +1,41 @@
+// @ts-expect-error
+import { parser } from '../grammar/selena.js'
+import { foldNodeProp, foldInside, LezerLanguage, LanguageSupport } from '@codemirror/language'
+import { styleTags, tags as t } from '@codemirror/highlight'
+
+// The following defines CodeMirror language support for Selena.
+// This is used for syntax highlighting, code folding, and perhaps more.
+
+const parserWithMetadata = parser.configure({
+  props: [
+    styleTags({
+      String: t.string,
+      LineComment: t.lineComment,
+      Arrow: t.controlOperator,
+      'ObjectDefinition/ObjectKeyword': t.definitionKeyword,
+      ReturnKeyword: t.controlKeyword,
+      ObjectName: t.local(t.variableName),
+      Outside: t.constant(t.variableName),
+      Option: t.annotation,
+      '( )': t.paren,
+      '{ }': t.brace,
+      '=': t.definitionOperator
+    }),
+    foldNodeProp.add({
+      MessageBlock: foldInside
+    })
+  ]
+})
+
+export const selenaLanguage = LezerLanguage.define({
+  parser: parserWithMetadata,
+  languageData: {
+    commentTokens: {
+      line: '#'
+    }
+  }
+})
+
+export function selena (): LanguageSupport {
+  return new LanguageSupport(selenaLanguage)
+}


### PR DESCRIPTION
This adds a Lezer grammar file for the Selena language.
Via `npm run build-grammar` the parser can be generated, which is included as an editor extension for syntax highlighting.