### PR TITLE
feat(editor): Implement CodeMirror linter to display errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,18 @@ import { BrowserSvgRenderer, compileToSequence, Diagram } from 'selena'
 import { basicSetup, EditorState } from '@codemirror/basic-setup'
 import { Command, EditorView, keymap } from '@codemirror/view'
 import { defaultTabBinding } from '@codemirror/commands'
+import { linter } from '@codemirror/lint'
 import { oneDark } from '@codemirror/theme-one-dark'
 
 import { selena } from './selena-language-support'
+import { selenaLinter } from './selena-linter'
 
 const LOCALSTORAGE_SAVED = 'seq.save.input'
+
+/**
+ * Time before linter runs, in milliseconds.
+ */
+const LINT_DELAY = 250
 
 function update (input: string, outputTo: HTMLElement): void {
   const diag = Diagram.create(compileToSequence(input))
@@ -63,6 +70,9 @@ const editorView = new EditorView({
         { key: 'Ctrl-s', run: updateDiagram }
       ]),
       EditorState.tabSize.of(2),
+      linter(selenaLinter, {
+        delay: LINT_DELAY
+      }),
       oneDark
     ],
     doc: loadDocument()

--- a/src/selena-linter.ts
+++ b/src/selena-linter.ts
@@ -1,0 +1,27 @@
+import { EditorView } from '@codemirror/view'
+import { Diagnostic } from '@codemirror/lint'
+import { compileToSequence, ParserError, TokenizerError } from 'selena'
+
+function convertError (e: any): Diagnostic {
+  let from = 0
+  let to = 0
+  if (e instanceof TokenizerError) {
+    from = to = e.position
+  } else if (e instanceof ParserError) {
+    from = e.token.position
+    to = e.token.position + e.token.value.length
+  }
+  return { from, to, severity: 'error', message: e?.toString() ?? '' }
+}
+
+export function selenaLinter (view: EditorView): Diagnostic[] {
+  const input = view.state.doc.sliceString(0)
+
+  try {
+    compileToSequence(input)
+  } catch (e) {
+    return [convertError(e)]
+  }
+
+  return []
+}


### PR DESCRIPTION
This implements a CodeMirror lint source that tries to compile a sequence from the given input, and when that fails, displays the error message as an inline diagnostic.