### PR TITLE
feat(formatting): Implement auto-reformatting of input script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
   <header id="header">
     <div class="header-logo">Selena IDE</div>
     <button class="header-btn" id="btn-compile">Compile (Ctrl-S)</button>
+    <button class="header-btn" id="btn-reformat">Reformat (Ctrl-Alt-L)</button>
   </header>
 
   <main id="main">

--- a/public/style.css
+++ b/public/style.css
@@ -36,7 +36,7 @@ body {
   padding: 0 12px;
   font: inherit;
   line-height: 1;
-  background: #282;
+  background: #6a6a6a;
   color: #fff;
   border: 1px solid transparent;
   border-radius: 4px;
@@ -47,6 +47,10 @@ body {
 .header-btn:hover,
 .header-btn:focus {
   border-color: #eee;
+}
+
+#btn-compile {
+  background: #282;
 }
 
 #main {

--- a/src/formatter/format.ts
+++ b/src/formatter/format.ts
@@ -1,0 +1,73 @@
+import { tokenize, TokenType } from 'selena'
+import { Formatter, Separator } from './formatter'
+import { WhitespaceMemory } from './whitespace-memory'
+import { matching, matchingAnything, matchingNothing } from './pattern/patterns'
+import { Pattern } from './pattern/pattern'
+
+function formatOptions (): Pattern {
+  return matching(TokenType.PAREN_LEFT)
+    .any({})
+    .repeat()
+    .until(TokenType.PAREN_RIGHT)
+}
+
+function formatReturn (): Pattern {
+  return matching(TokenType.WORD, 'return')
+    .matching({ before: Separator.SPACE }, TokenType.STRING)
+}
+
+function formatMessageBlock (): Pattern {
+  return matching(TokenType.BLOCK_LEFT)
+    .withOneOf({ before: Separator.NEWLINE, after: Separator.NEWLINE }, [
+      formatReturn,
+      formatFoundMessage,
+      formatMessage,
+      matchingAnything
+    ])
+    .repeat()
+    .indentContent()
+    .until(TokenType.BLOCK_RIGHT)
+}
+
+function formatMessage (): Pattern {
+  return matching(TokenType.ARROW)
+    .with({ after: Separator.SPACE }, formatOptions)
+    .any({}) // target
+    .matching({ before: Separator.SPACE }, TokenType.STRING)
+    .with({ before: Separator.SPACE }, formatMessageBlock)
+}
+
+function formatFoundMessage (): Pattern {
+  return matching(TokenType.WORD, '*')
+    .with({}, formatMessage)
+}
+
+function formatObject (): Pattern {
+  return matching(TokenType.WORD, 'object')
+    .with({}, formatOptions)
+    .any({ before: Separator.SPACE }) // name
+    .any({ before: Separator.SPACE, after: Separator.SPACE }) // '='
+    .any({}) // label
+}
+
+function formatAll (): Pattern {
+  return matchingNothing()
+    .withOneOf({ after: Separator.NEWLINE }, [
+      formatObject,
+      formatFoundMessage,
+      formatMessage,
+      matchingAnything
+    ])
+    .repeat()
+}
+
+export function format (input: string): string {
+  const tokens = tokenize(input)
+  const formatter = new Formatter(tokens, new WhitespaceMemory(input), {
+    keepEmptyLines: 1
+  })
+
+  formatAll().apply(formatter)
+
+  return formatter.getResult()
+}

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -1,0 +1,117 @@
+import { Token, TokenStream, TokenType } from 'selena'
+import { IndentingStringWriter } from './indenting-string-writer'
+import { WhitespaceMemory } from './whitespace-memory'
+
+export enum Separator {
+  NONE,
+  SPACE,
+  NEWLINE
+}
+
+export interface FormatterOptions {
+  readonly keepEmptyLines: number
+}
+
+function separatorToString (sep: Separator): string {
+  switch (sep) {
+    case Separator.NONE:
+      return ''
+    case Separator.SPACE:
+      return ' '
+    case Separator.NEWLINE:
+      return '\n'
+  }
+}
+
+export class Formatter {
+  private readonly tokens: TokenStream
+  private readonly whitespace: WhitespaceMemory
+  private readonly options: FormatterOptions
+
+  private readonly output = new IndentingStringWriter()
+
+  private first: boolean = true
+  private bufferedSeparator: Separator = Separator.NONE
+
+  constructor (tokens: TokenStream, whitespace: WhitespaceMemory, options: FormatterOptions) {
+    this.tokens = tokens
+    this.whitespace = whitespace
+    this.options = options
+  }
+
+  getResult () {
+    return this.output.toString() + '\n'
+  }
+
+  hasNext () {
+    return this.tokens.hasNext()
+  }
+
+  private getAppropriateSeparator (minimumSep: Separator, token: Token, allowMultiline = false): string {
+    const newlines = this.whitespace.getLinebreaksBefore(token)
+    if (newlines === 0 || !allowMultiline) {
+      return separatorToString(minimumSep)
+    }
+    const newlinesAllowed = this.options.keepEmptyLines + 1
+    return '\n'.repeat(Math.min(newlinesAllowed, newlines))
+  }
+
+  private appendToken (minimumSep: Separator) {
+    const token = this.tokens.next()
+    // do not append a separator if this is the first token
+    if (!this.first) {
+      // empty lines between tokens are allowed to be kept for comments, or for pairs of tokens
+      // where the separator is a newline
+      // (in other words, tokens normally separated by a space cannot be separated by a newline)
+      const multiline = token.type === TokenType.COMMENT || minimumSep === Separator.NEWLINE
+      const sep = this.getAppropriateSeparator(minimumSep, token, multiline)
+      this.output.write(sep)
+    }
+    this.output.write(token.value)
+    this.first = false
+  }
+
+  private processComments (): void {
+    while (this.tokens.hasNext()) {
+      const token = this.tokens.peek()
+      if (token.type !== TokenType.COMMENT) break
+      this.appendToken(Separator.SPACE)
+      // force a newline after a comment
+      this.bufferedSeparator = Separator.NEWLINE
+    }
+  }
+
+  matches (type: TokenType, value?: string): boolean {
+    this.processComments()
+    if (!this.tokens.hasNext()) {
+      return false
+    }
+    const next = this.tokens.peek()
+    return next.type === type && (value == null || next.value === value)
+  }
+
+  append (): this {
+    this.processComments()
+    if (this.tokens.hasNext()) {
+      this.appendToken(this.bufferedSeparator)
+      this.bufferedSeparator = Separator.NONE
+    }
+    return this
+  }
+
+  separate (sep: Separator): this {
+    // if multiple separators are requested, use the largest one
+    this.bufferedSeparator = Math.max(this.bufferedSeparator, sep)
+    return this
+  }
+
+  indent (): this {
+    ++this.output.indentation
+    return this
+  }
+
+  dedent (): this {
+    --this.output.indentation
+    return this
+  }
+}

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -39,11 +39,11 @@ export class Formatter {
     this.options = options
   }
 
-  getResult () {
+  getResult (): string {
     return this.output.toString() + '\n'
   }
 
-  hasNext () {
+  hasNext (): boolean {
     return this.tokens.hasNext()
   }
 
@@ -56,7 +56,7 @@ export class Formatter {
     return '\n'.repeat(Math.min(newlinesAllowed, newlines))
   }
 
-  private appendToken (minimumSep: Separator) {
+  private appendToken (minimumSep: Separator): void {
     const token = this.tokens.next()
     // do not append a separator if this is the first token
     if (!this.first) {

--- a/src/formatter/indenting-string-writer.ts
+++ b/src/formatter/indenting-string-writer.ts
@@ -1,0 +1,33 @@
+export class IndentingStringWriter {
+  private readonly indentWith: string
+
+  private out: string = ''
+  indentation: number = 0
+
+  constructor (indentWith = '\t') {
+    this.indentWith = indentWith
+  }
+
+  write (str: string): this {
+    const lines = str.split('\n')
+    for (let i = 0; i < lines.length - 1; ++i) {
+      this.writeLine(lines[i], true)
+    }
+    this.writeLine(lines[lines.length - 1], false)
+    return this
+  }
+
+  private writeLine (line: string, terminated: boolean): void {
+    if (this.out.length > 0 && this.out.endsWith('\n')) {
+      this.out += this.indentWith.repeat(this.indentation)
+    }
+    this.out += line
+    if (terminated) {
+      this.out += '\n'
+    }
+  }
+
+  toString (): string {
+    return this.out
+  }
+}

--- a/src/formatter/pattern/alternative-pattern.ts
+++ b/src/formatter/pattern/alternative-pattern.ts
@@ -1,0 +1,23 @@
+import { Formatter } from '../formatter'
+import { Pattern } from './pattern'
+
+export class AlternativePattern implements Pattern {
+  constructor (
+    private readonly options: Array<() => Pattern>
+  ) {
+  }
+
+  test (formatter: Formatter): boolean {
+    return this.options.some(option => option().test(formatter))
+  }
+
+  apply (formatter: Formatter): void {
+    for (const option of this.options) {
+      const pattern = option()
+      if (pattern.test(formatter)) {
+        pattern.apply(formatter)
+        return
+      }
+    }
+  }
+}

--- a/src/formatter/pattern/base-repeated-pattern.ts
+++ b/src/formatter/pattern/base-repeated-pattern.ts
@@ -18,16 +18,23 @@ export class BaseRepeatedPattern implements RepeatedPattern {
     return this.start.test(formatter)
   }
 
-  apply (formatter: Formatter): void {
-    this.start.apply(formatter)
+  private applyContent (formatter: Formatter): void {
     if (this.indent) {
       formatter.indent()
     }
     while (formatter.hasNext() && (this.end == null || !formatter.matches(this.end))) {
       this.content.forEach(item => item.tryApply(formatter))
     }
-    if (this.indent) formatter.dedent()
-    if (this.until != null) {
+    if (this.indent) {
+      formatter.dedent()
+    }
+  }
+
+  apply (formatter: Formatter): void {
+    // apply the start, then the content, then the closing token (if one is configured)
+    this.start.apply(formatter)
+    this.applyContent(formatter)
+    if (this.end != null) {
       formatter.append()
     }
   }

--- a/src/formatter/pattern/base-repeated-pattern.ts
+++ b/src/formatter/pattern/base-repeated-pattern.ts
@@ -1,0 +1,44 @@
+import { TokenType } from 'selena'
+import { Formatter } from '../formatter'
+import { Pattern, RepeatedPattern, SimplePattern } from './pattern'
+import { BaseSimplePattern } from './base-simple-pattern'
+import { PatternItem } from './pattern-item'
+
+export class BaseRepeatedPattern implements RepeatedPattern {
+  private end: TokenType | undefined
+  private indent: boolean = false
+
+  constructor (
+    private readonly start: Pattern,
+    private readonly content: PatternItem[]
+  ) {
+  }
+
+  test (formatter: Formatter): boolean {
+    return this.start.test(formatter)
+  }
+
+  apply (formatter: Formatter): void {
+    this.start.apply(formatter)
+    if (this.indent) {
+      formatter.indent()
+    }
+    while (formatter.hasNext() && (this.end == null || !formatter.matches(this.end))) {
+      this.content.forEach(item => item.tryApply(formatter))
+    }
+    if (this.indent) formatter.dedent()
+    if (this.until != null) {
+      formatter.append()
+    }
+  }
+
+  until (type: TokenType): SimplePattern {
+    this.end = type
+    return new BaseSimplePattern(this)
+  }
+
+  indentContent (): this {
+    this.indent = true
+    return this
+  }
+}

--- a/src/formatter/pattern/base-simple-pattern.ts
+++ b/src/formatter/pattern/base-simple-pattern.ts
@@ -1,0 +1,52 @@
+import { TokenType } from 'selena'
+import { Formatter } from '../formatter'
+import { Pattern, RepeatedPattern, Separators, SimplePattern } from './pattern'
+import { SingleTokenPattern } from './single-token-pattern'
+import { BaseRepeatedPattern } from './base-repeated-pattern'
+import { AlternativePattern } from './alternative-pattern'
+import { PatternItem } from './pattern-item'
+
+export class BaseSimplePattern implements SimplePattern {
+  private readonly next: PatternItem[] = []
+
+  constructor (
+    private readonly start: Pattern
+  ) {
+  }
+
+  test (formatter: Formatter): boolean {
+    return this.start.test(formatter)
+  }
+
+  apply (formatter: Formatter): void {
+    this.start.apply(formatter)
+    this.next.forEach(item => item.tryApply(formatter))
+  }
+
+  any (sep: Separators): this {
+    const pattern = new SingleTokenPattern(undefined, undefined, true)
+    this.next.push(new PatternItem(sep, () => pattern))
+    return this
+  }
+
+  matching (sep: Separators, type: TokenType, value?: string): this {
+    const pattern = new SingleTokenPattern(type, value, true)
+    this.next.push(new PatternItem(sep, () => pattern))
+    return this
+  }
+
+  with (sep: Separators, fn: () => Pattern): this {
+    this.next.push(new PatternItem(sep, fn))
+    return this
+  }
+
+  withOneOf (sep: Separators, fns: Array<() => Pattern>): this {
+    const pattern = new AlternativePattern(fns)
+    this.next.push(new PatternItem(sep, () => pattern))
+    return this
+  }
+
+  repeat (): RepeatedPattern {
+    return new BaseRepeatedPattern(this.start, this.next)
+  }
+}

--- a/src/formatter/pattern/pattern-item.ts
+++ b/src/formatter/pattern/pattern-item.ts
@@ -1,0 +1,25 @@
+import { Formatter } from '../formatter'
+import { Pattern, Separators } from './pattern'
+
+export class PatternItem {
+  constructor (
+    private readonly sep: Separators,
+    private readonly patternProvider: () => Pattern
+  ) {
+  }
+
+  tryApply (formatter: Formatter): boolean {
+    const pattern = this.patternProvider()
+    if (pattern.test(formatter)) {
+      if (this.sep.before != null) {
+        formatter.separate(this.sep.before)
+      }
+      pattern.apply(formatter)
+      if (this.sep.after != null) {
+        formatter.separate(this.sep.after)
+      }
+      return true
+    }
+    return false
+  }
+}

--- a/src/formatter/pattern/pattern.ts
+++ b/src/formatter/pattern/pattern.ts
@@ -1,0 +1,31 @@
+import { TokenType } from 'selena'
+import { Formatter, Separator } from '../formatter'
+
+export interface Separators {
+  before?: Separator
+  after?: Separator
+}
+
+export interface Pattern {
+  test: (formatter: Formatter) => boolean
+
+  apply: (formatter: Formatter) => void
+}
+
+export interface SimplePattern extends Pattern {
+  any: (sep: Separators) => this
+
+  matching: (sep: Separators, type: TokenType, value?: string) => this
+
+  with: (sep: Separators, fn: () => Pattern) => this
+
+  withOneOf: (sep: Separators, fns: Array<() => Pattern>) => this
+
+  repeat: () => RepeatedPattern
+}
+
+export interface RepeatedPattern extends Pattern {
+  until: (type: TokenType) => SimplePattern
+
+  indentContent: () => this
+}

--- a/src/formatter/pattern/patterns.ts
+++ b/src/formatter/pattern/patterns.ts
@@ -1,0 +1,16 @@
+import { TokenType } from 'selena'
+import { BaseSimplePattern } from './base-simple-pattern'
+import { SingleTokenPattern } from './single-token-pattern'
+import { SimplePattern } from './pattern'
+
+export function matching (type: TokenType, value?: string): SimplePattern {
+  return new BaseSimplePattern(new SingleTokenPattern(type, value, true))
+}
+
+export function matchingAnything (): SimplePattern {
+  return new BaseSimplePattern(new SingleTokenPattern(undefined, undefined, true))
+}
+
+export function matchingNothing (): SimplePattern {
+  return new BaseSimplePattern(new SingleTokenPattern(undefined, undefined, false))
+}

--- a/src/formatter/pattern/single-token-pattern.ts
+++ b/src/formatter/pattern/single-token-pattern.ts
@@ -1,0 +1,22 @@
+import { TokenType } from 'selena'
+import { Formatter } from '../formatter'
+import { Pattern } from './pattern'
+
+export class SingleTokenPattern implements Pattern {
+  constructor (
+    private readonly type: TokenType | undefined,
+    private readonly value: string | undefined,
+    private readonly consume: boolean
+  ) {
+  }
+
+  test (formatter: Formatter): boolean {
+    return this.type == null || formatter.matches(this.type, this.value)
+  }
+
+  apply (formatter: Formatter): void {
+    if (this.consume) {
+      formatter.append()
+    }
+  }
+}

--- a/src/formatter/whitespace-memory.ts
+++ b/src/formatter/whitespace-memory.ts
@@ -1,0 +1,23 @@
+import { Token } from 'selena'
+
+export class WhitespaceMemory {
+  private readonly input: string
+
+  constructor (input: string) {
+    this.input = input
+  }
+
+  getLinebreaksBefore (token: Token): number {
+    let count = 0
+    for (let pos = token.position - 1; pos >= 0; --pos) {
+      const c = this.input.charAt(pos)
+      if (!/\s/.test(c)) {
+        break
+      }
+      if (c === '\n') {
+        ++count
+      }
+    }
+    return count
+  }
+}


### PR DESCRIPTION
This adds an editor action to trigger automatic reformatting of the input according to my personal stylistic preferences for this language.

Whitespace between tokens is replaced with the respectively correct amount and sort (i.e., a single space or a single newline).
In case where the separator is a newline and the input already contained multiple newlines (i.e., one or more empty lines between statements), one empty line is kept. Comments are also handled correctly.
The formatter is very forgiving and even handles abruptly ending input gracefully, formatting everything up until the end of the script.