### PR TITLE
fix(preview): Make svg selector (for font-family) generic

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -102,7 +102,7 @@ body {
   opacity: 0.5;
 }
 
-#preview > svg {
+svg {
   font-family: sans-serif;
 }
 


### PR DESCRIPTION
Selena appends an SVG element to the end of the body for taking measurements.
Therefore, the SVG element needs to be styled the same as the actual preview one.