### PR TITLE
fix: Avoid computing Array indexes from end

### DIFF
--- a/src/formatter/indenting-string-writer.ts
+++ b/src/formatter/indenting-string-writer.ts
@@ -10,10 +10,9 @@ export class IndentingStringWriter {
 
   write (str: string): this {
     const lines = str.split('\n')
-    for (let i = 0; i < lines.length - 1; ++i) {
-      this.writeLine(lines[i], true)
+    for (const [index, line] of str.split('\n').entries()) {
+      this.writeLine(line, index < lines.length - 1)
     }
-    this.writeLine(lines[lines.length - 1], false)
     return this
   }
 

--- a/src/pdf-renderer/pdf-renderer.ts
+++ b/src/pdf-renderer/pdf-renderer.ts
@@ -109,8 +109,24 @@ export class PdfRenderer implements DirectRenderer<PDFKit.PDFDocument> {
     }
     this.doc.stroke('black')
     this.doc.restore()
-    this.renderMarker(end1, points[0], computeAngle(points[0], points[1]), lineWidth)
-    this.renderMarker(end2, points[points.length - 1], computeAngle(points[points.length - 2], points[points.length - 1]), lineWidth)
+    this.renderStartMarker(points, end1, lineWidth)
+    this.renderEndMarker(points, end2, lineWidth)
+  }
+
+  private renderStartMarker (points: Point[], marker: LineMarker, lineWidth: number): void {
+    const position = points.at(0)
+    const nextPosition = points.at(1)
+    if (position != null && nextPosition != null) {
+      this.renderMarker(marker, position, computeAngle(position, nextPosition), lineWidth)
+    }
+  }
+
+  private renderEndMarker (points: Point[], marker: LineMarker, lineWidth: number): void {
+    const position = points.at(-1)
+    const previousPosition = points.at(-2)
+    if (position != null && previousPosition != null) {
+      this.renderMarker(marker, position, computeAngle(previousPosition, position), lineWidth)
+    }
   }
 
   renderPath (data: string, offset: Point, options?: StrokeOptions): void {


### PR DESCRIPTION
Use `Array.prototype.at()` and a `for...of` loop over `.entries()` to prevent having to do `array[array.length - index]`.