### PR TITLE
fix: Set type to "module" to let Vite build in ESM mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "description": "IDE for the Selena language, a textual description of renderable UML sequence diagrams.",
-  "main": "index.js",
+  "type": "module",
   "scripts": {
     "clean": "rimraf dist && rimraf \"grammar/*.js\"",
     "build-grammar": "lezer-generator grammar/selena.grammar -o grammar/selena.js",


### PR DESCRIPTION
Up until now the project ran in CommonJS mode, which is now deprecated by Vite v5:

> The CJS build of Vite's Node API is deprecated. See
> https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated
> for more details.

Set the type to "module" to fix this.